### PR TITLE
fix a dataloading bug for svhn2mnist.

### DIFF
--- a/cycada/data/cyclegan.py
+++ b/cycada/data/cyclegan.py
@@ -22,7 +22,7 @@ class CycleGANDataset(data.Dataset):
         image_paths = []
         labels = []
         for basename in basenames:
-            image_paths.append(os.path.join(self.root, basename))
+            image_paths.append(basename)
             labels.append(int(basename.split('/')[-1].split('_')[0]))
         return image_paths, labels
 


### PR DESCRIPTION
The path to the root got added to image path twice. Each basename already has the root folder from line 21.